### PR TITLE
fix: update blockstack

### DIFF
--- a/configs/blockstack.json
+++ b/configs/blockstack.json
@@ -1,10 +1,10 @@
 {
   "index_name": "blockstack",
   "start_urls": [
-    "https://docs.blockstack.org/"
+    "https://docs.stacks.co/"
   ],
   "sitemap_urls": [
-    "https://docs.blockstack.org/sitemap.xml"
+    "https://docs.stacks.co/sitemap.xml"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
We've changed our domain from `docs.blockstack.org` to `docs.stacks.co`, same content, just a redirect.